### PR TITLE
fix: do not create a sliced file, output multiple csv files instead

### DIFF
--- a/tests/Keboola/ExEmailAttachments/Functional/RunTest.php
+++ b/tests/Keboola/ExEmailAttachments/Functional/RunTest.php
@@ -64,18 +64,13 @@ class RunTest extends AbstractTest
         $this->assertArrayHasKey('incremental', $manifest);
         $this->assertArrayHasKey('enclosure', $manifest);
         $this->assertArrayHasKey('delimiter', $manifest);
-        $this->assertArrayHasKey('columns', $manifest);
         $this->assertEquals(true, $manifest['incremental']);
         $this->assertEquals('"', $manifest['enclosure']);
         $this->assertEquals(',', $manifest['delimiter']);
-        $this->assertEquals(['id', 'name', 'order'], $manifest['columns']);
 
-        $this->assertDirectoryExists("$dataFolder/data.csv");
-        $csvFiles = glob("$dataFolder/data.csv/*");
-        $this->assertCount(1, $csvFiles);
-
-        $file1 = file($csvFiles[0]);
-        $this->assertCount(5, $file1);
-        $this->assertEquals('"c1","Category 1","1"', trim($file1[0]));
+        $this->assertFileExists("$dataFolder/data.csv");
+        $file = file("$dataFolder/data.csv");
+        $this->assertCount(6, $file);
+        $this->assertEquals('"id","name","order"', trim($file[0]));
     }
 }

--- a/tests/Keboola/ExEmailAttachments/Unit/RunActionTest.php
+++ b/tests/Keboola/ExEmailAttachments/Unit/RunActionTest.php
@@ -208,18 +208,22 @@ class RunActionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFileExists("{$this->temp->getTmpFolder()}/data.csv.manifest");
         $manifest = json_decode(file_get_contents("{$this->temp->getTmpFolder()}/data.csv.manifest"), true);
-        $this->assertArrayHasKey('columns', $manifest);
-        $this->assertEquals(['id', 'name', 'order'], $manifest['columns']);
+        $this->assertArrayHasKey('delimiter', $manifest);
+        $this->assertEquals(';', $manifest['delimiter']);
 
-        $this->assertDirectoryExists("{$this->temp->getTmpFolder()}/data.csv");
-        $csvFiles = glob($this->temp->getTmpFolder().'/data.csv/*');
-        $this->assertCount(2, $csvFiles);
+        $this->assertFileExists("{$this->temp->getTmpFolder()}/data1.csv.manifest");
+        $manifest = json_decode(file_get_contents("{$this->temp->getTmpFolder()}/data1.csv.manifest"), true);
+        $this->assertArrayHasKey('delimiter', $manifest);
+        $this->assertEquals(';', $manifest['delimiter']);
 
-        $file1 = file($csvFiles[0]);
-        $this->assertCount(2, $file1);
-        $this->assertNotEquals('id,name,order', $file1[0]);
-        $file2 = file($csvFiles[1]);
-        $this->assertCount(2, $file2);
-        $this->assertNotEquals('id,name,order', $file1[0]);
+        $this->assertFileExists("{$this->temp->getTmpFolder()}/data.csv");
+        $file1 = file("{$this->temp->getTmpFolder()}/data.csv");
+        $this->assertCount(3, $file1);
+        $this->assertEquals('id;name;order', trim($file1[0]));
+
+        $this->assertFileExists("{$this->temp->getTmpFolder()}/data1.csv");
+        $file2 = file("{$this->temp->getTmpFolder()}/data1.csv");
+        $this->assertCount(3, $file2);
+        $this->assertEquals('id;name;order', trim($file1[0]));
     }
 }


### PR DESCRIPTION
- Takže, slice tabulka se vytvářet nebude. 
- Místo toho se příchozí soubory jen zkopírují do `out/tables`, díky čemuž budou fungovat procesory. 
- První soubor se jmenuje `data.csv`, takže to bude fungovat jako dosud.
- Další soubory se jmenují `data1.csv`, atd. Spojení do jedný tabulky tak zůstane na klientech.